### PR TITLE
feat: Update footer link and set global site font

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -152,12 +152,14 @@ const formFields = [
 					them non-editable, check the "Flatten PDFs" option. This will merge
 					the form fields with the PDF content, preventing any further changes.
 				</p>
-				<p
-					class="border border-dashed border-red-600 px-3 py-2 text-sm text-red-600"
-				>
-					⚠ There is a known issue where flattening may cause issues with Adobe
-					Acrobat.
-				</p>
+				<a href="https://github.com/jrwnnnn/rekord/issues/6" target="_blank">
+					<p
+						class="border border-dashed border-red-600 px-3 py-2 text-sm text-red-600 hover:bg-red-50"
+					>
+						⚠ There is a known issue where flattening may cause issues with
+						Adobe Acrobat.
+					</p>
+				</a>
 
 				<div class="mt-5 flex items-center gap-2">
 					<input

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -197,7 +197,7 @@ const formFields = [
 			<p>
 				&copy; {new Date().getFullYear()} Mark Jerwin.
 				<a
-					href="https://github.com/jrwnnnn/sf10"
+					href="https://github.com/jrwnnnn/rekord"
 					target="_blank"
 					class="text-blue-600 underline hover:text-blue-800"
 				>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -154,7 +154,7 @@ const formFields = [
 				</p>
 				<a href="https://github.com/jrwnnnn/rekord/issues/6" target="_blank">
 					<p
-						class="border border-dashed border-red-600 px-3 py-2 text-sm text-red-600 hover:bg-red-50"
+						class="border border-dashed border-red-600 px-3 py-2 text-sm text-red-600 hover:bg-red-50 cursor-pointer"
 					>
 						⚠ There is a known issue where flattening may cause issues with
 						Adobe Acrobat.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -37,7 +37,7 @@ const formFields = [
 ---
 
 <Layout title="Rekord BETA">
-	<main class="mx-auto max-w-3xl bg-white p-8 font-['courier_new'] text-black">
+	<main class="mx-auto max-w-3xl bg-white p-8 text-black">
 		<form id="mainForm" class="space-y-8">
 			<header class="pb-4">
 				<div class="flex gap-2">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,6 +1,13 @@
+@import url("https://fonts.googleapis.com/css2?family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap");
 @import "tailwindcss";
+
+@theme {
+	--font-space-mono: "Space Mono", monospace;
+}
+
 body {
 	@apply flex min-h-dvh flex-col overflow-x-hidden;
+	@apply font-space-mono flex min-h-dvh flex-col overflow-x-hidden;
 }
 
 main {


### PR DESCRIPTION
* The default font for the site is changed to use `"Space Mono"` instead of `"Courier New"` by updating both the global CSS and removing the explicit font class from the main container in `index.astro`. 
* The warning message about PDF flattening is now wrapped in a link to the relevant GitHub issue.
* The GitHub repository link in the page footer is corrected from `jrwnnnn/sf10` to `jrwnnnn/rekord`.