### PR TITLE
refactor: Simplify class info mapping 

### DIFF
--- a/src/data/htmlFields.json
+++ b/src/data/htmlFields.json
@@ -1,8 +1,5 @@
 [
 	{
-		"name": "classified_as_grade"
-	},
-	{
 		"name": "name_of_school",
 		"label": "School Name"
 	},

--- a/src/lib/populateFields.ts
+++ b/src/lib/populateFields.ts
@@ -18,8 +18,10 @@ export async function populateFields(
 		`Creating SF10 for ${csvRow["learner.last_name"]}, ${csvRow["learner.first_name"]}...`,
 	);
 
-	//Populate school and class info fields based of the HTML form
-	const skipFields = [
+	const gradeLevel = htmlFormValues.classified_as_grade;
+
+	//Populate school/class info fields based of the HTML form
+	const SKIP_FIELDS = [
 		"file",
 		"flatten",
 		"passing_criteria",
@@ -28,10 +30,10 @@ export async function populateFields(
 	];
 
 	for (const [htmlFieldName, value] of Object.entries(htmlFormValues)) {
-		if (skipFields.includes(htmlFieldName)) continue;
-		const pdfFieldName = `record_${htmlFormValues.classified_as_grade}.${htmlFieldName}`;
-		const pdfField = form.getTextField(pdfFieldName);
-		pdfField.setText(String(value || ""));
+		if (SKIP_FIELDS.includes(htmlFieldName)) continue;
+		form
+			.getTextField(`record_${gradeLevel}.${htmlFieldName}`)
+			.setText(String(value || ""));
 	}
 
 	// Populate the remaining fields based on the CSV
@@ -39,16 +41,14 @@ export async function populateFields(
 		// Handle checkbox fields
 		if (pdfFieldName === "credential_presented_for_grade_1") {
 			for (const [label, fieldName] of Object.entries(checkboxMap)) {
-				const checkbox = form.getCheckBox(fieldName);
 				if (value === "All" || value.includes(label)) {
-					checkbox.check();
+					form.getCheckBox(fieldName).check();
 				}
 			}
 			continue;
 		}
 
-		const pdfField = form.getTextField(pdfFieldName);
-		pdfField.setText(
+		form.getTextField(pdfFieldName).setText(
 			// For fields in the "learner." namespace, convert to uppercase.
 			pdfFieldName.includes("learner.")
 				? (value || "").toUpperCase()
@@ -56,8 +56,9 @@ export async function populateFields(
 		);
 	}
 
-	const schoolIdField = form.getTextField("enrollment.school_id");
-	schoolIdField.setText(csvRow["learner.lrn"]?.slice(0, 6) || "");
+	form
+		.getTextField("enrollment.school_id")
+		.setText(csvRow["learner.lrn"]?.slice(0, 6) || "");
 
 	// Scrape /AP and seed missing /DA for all text fields, then apply styling
 	for (const field of form.getFields()) {

--- a/src/lib/populateFields.ts
+++ b/src/lib/populateFields.ts
@@ -13,10 +13,9 @@ function shrinkToFit(
 	maxSize: number,
 	fieldWidth: number,
 	minSize = 6,
-	step = 0.5,
 ): number {
 	if (!text) return maxSize;
-	for (let size = maxSize; size >= minSize; size -= step) {
+	for (let size = maxSize; size >= minSize; size -= 1) {
 		if (font.widthOfTextAtSize(text, size) <= fieldWidth) {
 			return size;
 		}

--- a/src/lib/populateFields.ts
+++ b/src/lib/populateFields.ts
@@ -1,46 +1,11 @@
 ﻿import type { PDFForm, PDFFont } from "pdf-lib";
-import { PDFName, PDFTextField, TextAlignment } from "pdf-lib";
+import { PDFName, PDFTextField } from "pdf-lib";
+import { styleField } from "@utils/styleField";
 import checkboxMap from "../data/checkboxMap.json";
 
-export interface Fonts {
+interface Fonts {
 	arialBold: PDFFont;
 	arialNarrowBold: PDFFont;
-}
-
-function shrinkToFit(
-	text: string,
-	font: PDFFont,
-	maxSize: number,
-	fieldWidth: number,
-	minSize = 6,
-): number {
-	if (!text) return maxSize;
-	for (let size = maxSize; size >= minSize; size -= 1) {
-		if (font.widthOfTextAtSize(text, size) <= fieldWidth) {
-			return size;
-		}
-	}
-	return minSize;
-}
-
-function styleField(
-	field: PDFTextField,
-	fonts: Fonts,
-	pdfFieldName: string,
-): void {
-	const text = field.getText() ?? "";
-	const fieldWidth =
-		field.acroField.getWidgets()[0]?.getRectangle().width ?? Infinity;
-
-	if (pdfFieldName.startsWith("enrollment.")) {
-		field.setFontSize(shrinkToFit(text, fonts.arialNarrowBold, 11, fieldWidth));
-		field.setAlignment(TextAlignment.Left);
-		field.updateAppearances(fonts.arialNarrowBold);
-	} else {
-		field.setFontSize(shrinkToFit(text, fonts.arialBold, 12, fieldWidth));
-		field.setAlignment(TextAlignment.Center);
-		field.updateAppearances(fonts.arialBold);
-	}
 }
 
 export async function populateFields(

--- a/src/lib/populateFields.ts
+++ b/src/lib/populateFields.ts
@@ -47,18 +47,27 @@ function styleField(
 export async function populateFields(
 	form: PDFForm,
 	fonts: Fonts,
-	classInfo: Record<string, string>,
+	htmlFormValues: Record<string, FormDataEntryValue>,
 	csvRow: Record<string, string>,
 ) {
 	console.log(
 		`Creating SF10 for ${csvRow["learner.last_name"]}, ${csvRow["learner.first_name"]}...`,
 	);
 
-	// Populate school and class info fields based of the HTML form
-	for (const [htmlFieldName, value] of Object.entries(classInfo)) {
-		const pdfFieldName = `record_${classInfo.classified_as_grade}.${htmlFieldName}`;
+	//Populate school and class info fields based of the HTML form
+	const skipFields = [
+		"file",
+		"flatten",
+		"passing_criteria",
+		"promotion_criteria",
+		"classified_as_grade",
+	];
+
+	for (const [htmlFieldName, value] of Object.entries(htmlFormValues)) {
+		if (skipFields.includes(htmlFieldName)) continue;
+		const pdfFieldName = `record_${htmlFormValues.classified_as_grade}.${htmlFieldName}`;
 		const pdfField = form.getTextField(pdfFieldName);
-		pdfField.setText(value || "");
+		pdfField.setText(String(value || ""));
 	}
 
 	// Populate the remaining fields based on the CSV

--- a/src/lib/validateCSV.ts
+++ b/src/lib/validateCSV.ts
@@ -31,8 +31,8 @@ export function validateCSV(file: File, grade: number): Promise<boolean> {
 					let message = "";
 
 					if (missingColumns.length > 5) {
-						const shown = missingColumns.slice(0, 5).join(", ");
-						message = `Missing columns: ${shown}, and ${missingColumns.length - 5} more...`;
+						const shown = missingColumns.slice(0, 3).join(", ");
+						message = `Missing columns: ${shown}, and ${missingColumns.length - 3} more...`;
 					} else {
 						message = `Missing columns: ${missingColumns.join(", ")}`;
 					}

--- a/src/lib/validateCSV.ts
+++ b/src/lib/validateCSV.ts
@@ -2,9 +2,7 @@ import { updateProgressBanner } from "@utils/progressBanner";
 import Papa from "papaparse";
 import schema from "../data/schema.json";
 
-const grade = 4;
-
-export function validate(file: File): Promise<boolean> {
+export function validateCSV(file: File, grade: number): Promise<boolean> {
 	return new Promise((resolve) => {
 		// Check if the file is a CSV based on MIME type and extension
 		if (file.type !== "text/csv" && !file.name.toLowerCase().endsWith(".csv")) {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -185,7 +185,7 @@ import htmlFields from "../data/htmlFields.json";
 <script src="@utils/downloadTemplate.ts"></script>
 <script>
 	import { populateFields } from "@lib/populateFields";
-	import { validate } from "@lib/validateCSV";
+	import { validateCSV } from "@lib/validateCSV";
 	import { PDFDocument } from "pdf-lib";
 	import { updateProgressBanner } from "@utils/progressBanner";
 	import { saveAs } from "file-saver";
@@ -205,7 +205,13 @@ import htmlFields from "../data/htmlFields.json";
 
 		console.log("Parsing CSV file...");
 		updateProgressBanner("Parsing CSV file...");
-		if (!(await validate(csvFile))) return;
+		if (
+			!(await validateCSV(
+				csvFile,
+				parseInt(htmlFormValues.classified_as_grade as string),
+			))
+		) // fix: pass the selected grade level to the validateCSV function to check for the correct columns based on the grade schema
+			return;
 
 		// Load the PDF template and fonts
 		const template = await fetch("/acroforms/es.pdf").then((r) =>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -64,25 +64,22 @@ import htmlFields from "../data/htmlFields.json";
 						</select>
 					</div>
 					{
-						htmlFields.map(
-							(field) =>
-								field.name !== "classified_as_grade" && (
-									<div class="flex flex-col">
-										<label
-											for={`input${field.name}`}
-											class="mb-1 text-sm font-medium text-gray-700"
-										>
-											{field.label}:
-										</label>
-										<input
-											id={`input${field.name}`}
-											name={`input${field.name}`}
-											type="text"
-											class="grow border border-black px-2 py-2 text-sm focus:border-blue-600 focus:ring-1 focus:ring-blue-600 focus:outline-none"
-										/>
-									</div>
-								),
-						)
+						htmlFields.map((field) => (
+							<div class="flex flex-col">
+								<label
+									for={`${field.name}`}
+									class="mb-1 text-sm font-medium text-gray-700"
+								>
+									{field.label}:
+								</label>
+								<input
+									id={`${field.name}`}
+									name={`${field.name}`}
+									type="text"
+									class="grow border border-black px-2 py-2 text-sm focus:border-blue-600 focus:ring-1 focus:ring-blue-600 focus:outline-none"
+								/>
+							</div>
+						))
 					}
 				</div>
 			</div>
@@ -95,8 +92,8 @@ import htmlFields from "../data/htmlFields.json";
 						is greater than or equal to
 						<input
 							type="text"
-							id="criteria1"
-							name="criteria1"
+							id="passing_criteria"
+							name="passing_criteria"
 							value="75"
 							class="w-10 border-b border-gray-700 px-2 py-px text-sm font-bold focus:border-b-2 focus:border-blue-600 focus:outline-none"
 							disabled
@@ -107,8 +104,8 @@ import htmlFields from "../data/htmlFields.json";
 						Promote a student if his/her grade is greater than or equal to
 						<input
 							type="text"
-							id="criteria1"
-							name="criteria1"
+							id="promotion_criteria"
+							name="promotion_criteria"
 							value="75"
 							class="w-10 border-b border-gray-700 px-2 py-px text-sm font-bold focus:border-b-2 focus:border-blue-600 focus:outline-none"
 							disabled
@@ -193,7 +190,6 @@ import htmlFields from "../data/htmlFields.json";
 	import { updateProgressBanner } from "@utils/progressBanner";
 	import { saveAs } from "file-saver";
 	import fontkit from "@pdf-lib/fontkit";
-	import htmlFields from "../data/htmlFields.json";
 	import JSZip from "jszip";
 	import Papa from "papaparse";
 
@@ -202,16 +198,8 @@ import htmlFields from "../data/htmlFields.json";
 	htmlForm.addEventListener("submit", async (e) => {
 		e.preventDefault();
 
-		const csvFile = (htmlForm.file as HTMLInputElement).files?.[0];
-		const flatten = (htmlForm.flatten as HTMLInputElement).checked;
-		const classInfo = Object.fromEntries(
-			htmlFields.map((field: { name: string }) => [
-				field.name,
-				field.name === "classified_as_grade"
-					? (htmlForm.classified_as_grade as HTMLSelectElement).value
-					: (htmlForm[`input${field.name}`] as HTMLInputElement).value,
-			]),
-		);
+		const htmlFormValues = Object.fromEntries(new FormData(htmlForm).entries());
+		const csvFile = htmlFormValues.file as File;
 
 		if (!csvFile) return;
 
@@ -263,9 +251,9 @@ import htmlFields from "../data/htmlFields.json";
 						`Creating SF10 for ${row["learner.last_name"]}, ${row["learner.first_name"]}...`,
 					);
 
-					populateFields(acroform, fonts, classInfo, row);
+					populateFields(acroform, fonts, htmlFormValues, row);
 
-					if (flatten) {
+					if (htmlFormValues.flatten === "on") {
 						acroform.flatten();
 					}
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -151,7 +151,7 @@ import htmlFields from "../data/htmlFields.json";
 				/>
 				<div>
 					<h1 class="line-clamp-2 font-bold">Processing...</h1>
-					<p class="text-sm text-gray-700">
+					<p class="text-xs text-gray-700">
 						Feel free to keep working while we generate the files in the
 						background.
 					</p>

--- a/src/utils/styleField.ts
+++ b/src/utils/styleField.ts
@@ -1,0 +1,43 @@
+import type { PDFFont } from "pdf-lib";
+import { PDFTextField, TextAlignment } from "pdf-lib";
+
+interface Fonts {
+	arialBold: PDFFont;
+	arialNarrowBold: PDFFont;
+}
+
+function shrinkToFit(
+	text: string,
+	font: PDFFont,
+	maxSize: number,
+	fieldWidth: number,
+	minSize = 6,
+): number {
+	if (!text) return maxSize;
+	for (let size = maxSize; size >= minSize; size -= 1) {
+		if (font.widthOfTextAtSize(text, size) <= fieldWidth) {
+			return size;
+		}
+	}
+	return minSize;
+}
+
+export function styleField(
+	field: PDFTextField,
+	fonts: Fonts,
+	pdfFieldName: string,
+): void {
+	const text = field.getText() ?? "";
+	const fieldWidth =
+		field.acroField.getWidgets()[0]?.getRectangle().width ?? Infinity;
+
+	if (pdfFieldName.startsWith("enrollment.")) {
+		field.setFontSize(shrinkToFit(text, fonts.arialNarrowBold, 11, fieldWidth));
+		field.setAlignment(TextAlignment.Left);
+		field.updateAppearances(fonts.arialNarrowBold);
+	} else {
+		field.setFontSize(shrinkToFit(text, fonts.arialBold, 12, fieldWidth));
+		field.setAlignment(TextAlignment.Center);
+		field.updateAppearances(fonts.arialBold);
+	}
+}


### PR DESCRIPTION
* Refactored the way HTML form values are collected by passing a single `htmlFormValues` object throughout the code.
* `htmlFields.json` is now solely used for building the form UI and not for validation.
* Made passing and promotion criteria fields to use more unambiguous `id` and `name` attributes.
* Renamed the CSV validation function to `validateCSV` and updated its signature to accept a grade level. Also improved the missing columns message to show up to three columns, making the feedback more concise. 
* Moved the `styleField` function and its helper `shrinkToFit` to a separate `styleField.ts` file.
* Reduced the font size of the progress banner sub header.