### PR TITLE
feat: Added remarks population; enabled criteria inputs

### DIFF
--- a/src/lib/populateFields.ts
+++ b/src/lib/populateFields.ts
@@ -48,6 +48,20 @@ export async function populateFields(
 			continue;
 		}
 
+		// Handle remarks field based on final_rating
+		if (pdfFieldName.startsWith(`record_${gradeLevel}.final_rating.`)) {
+			const subjectCode = pdfFieldName.slice(
+				`record_${gradeLevel}.final_rating.`.length,
+			);
+			form
+				.getTextField(`record_${gradeLevel}.remarks.${subjectCode}`)
+				.setText(
+					Number(value) >= Number(htmlFormValues.passing_criteria)
+						? "Passed"
+						: "Failed",
+				);
+		}
+
 		form.getTextField(pdfFieldName).setText(
 			// For fields in the "learner." namespace, convert to uppercase.
 			pdfFieldName.includes("learner.")
@@ -56,9 +70,18 @@ export async function populateFields(
 		);
 	}
 
+	// Handle special cases for school_id and general_remark
 	form
 		.getTextField("enrollment.school_id")
 		.setText(csvRow["learner.lrn"]?.slice(0, 6) || "");
+	form
+		.getTextField(`record_${gradeLevel}.general_remark`)
+		.setText(
+			Number(csvRow[`record_${gradeLevel}.general_average`]) >=
+				Number(htmlFormValues.promotion_criteria)
+				? "Promoted"
+				: "Retained",
+		);
 
 	// Scrape /AP and seed missing /DA for all text fields, then apply styling
 	for (const field of form.getFields()) {
@@ -70,3 +93,5 @@ export async function populateFields(
 		styleField(field, fonts, field.getName());
 	}
 }
+
+// feat: Populate 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -84,7 +84,7 @@ import htmlFields from "../data/htmlFields.json";
 				</div>
 			</div>
 
-			<div class="space-y-2 opacity-50">
+			<div class="space-y-2">
 				<h2 class="font-bold">4. Define Passing Criteria</h2>
 				<div class="flex flex-wrap space-y-4">
 					<p class="text-sm text-gray-700">
@@ -96,7 +96,6 @@ import htmlFields from "../data/htmlFields.json";
 							name="passing_criteria"
 							value="75"
 							class="w-10 border-b border-gray-700 px-2 py-px text-sm font-bold focus:border-b-2 focus:border-blue-600 focus:outline-none"
-							disabled
 						/>. Otherwise, mark as <strong>"Failed"</strong>.
 					</p>
 
@@ -108,7 +107,6 @@ import htmlFields from "../data/htmlFields.json";
 							name="promotion_criteria"
 							value="75"
 							class="w-10 border-b border-gray-700 px-2 py-px text-sm font-bold focus:border-b-2 focus:border-blue-600 focus:outline-none"
-							disabled
 						/>. Otherwise, mark as <strong>"Retained"</strong>.
 					</p>
 				</div>


### PR DESCRIPTION
* In `populateFields.ts`, the script now sets the `remarks` field for each subject based on whether the grade meets the passing criteria, and sets the `general_remark` field based on whether the general average meets the promotion criteria. 