### PR TITLE
fix: Use absolute site URLs for canonical and og:url fixing #19

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,13 +1,14 @@
 // @ts-check
-import { defineConfig } from 'astro/config';
+import { defineConfig } from "astro/config";
 import tailwindcss from "@tailwindcss/vite";
 import vercel from "@astrojs/vercel";
 
 // https://astro.build/config
 export default defineConfig({
-  vite: {
-    plugins: [tailwindcss()],
-  },
-  output: 'static',
-  adapter: vercel({})
+	site: "https://sf10.vercel.app",
+	vite: {
+		plugins: [tailwindcss()],
+	},
+	output: "static",
+	adapter: vercel({}),
 });

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -15,14 +15,14 @@ const {
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<link rel="canonical" href={Astro.url} />
+		<link rel="canonical" href={new URL(Astro.url.pathname, Astro.site).href} />
 
 		<title>{title}</title>
 		<meta name="description" content={description} />
 		<meta name="robots" content={robots} />
 
 		<meta property="og:type" content={ogType} />
-		<meta property="og:url" content={Astro.url} />
+		<meta property="og:url" content={new URL(Astro.url.pathname, Astro.site).href} />
 		<meta property="og:title" content={title} />
 		<meta property="og:description" content={description} />
 		<meta property="og:image" content={image} />


### PR DESCRIPTION
* Set the `site` property in `astro.config.mjs` to the production URL.
* Updated the canonical and Open Graph URL generation in `Layout.astro` to use absolute URLs based on the configured site resolving #18.
