### PR TITLE
fix: Use absolute URL for meta image

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -6,7 +6,7 @@ const {
 	description = "Hello! It's Jerwin! I'm a student based in Manila, PH. I build things for the web. My code is held together by duct tape and prayers. I spend more time customizing my VS Code theme than actually coding. If you see a bug, no you didn't.",
 	robots = "index, follow",
 	ogType = "website",
-	image = "meta/meta-image.jpg"
+	image = "https://sf10.vercel.app/meta/meta-image.jpg"
 } = Astro.props;
 ---
 


### PR DESCRIPTION
* Updated the `og:image` path from a relative link to an absolute URL since social media scrapers and messaging platforms cannot resolve relative paths.
* This PR resolves #18.